### PR TITLE
fix: ARプロフィールの非表示・横幅圧縮を修正

### DIFF
--- a/src/components/features/introduction/ARProfile.astro
+++ b/src/components/features/introduction/ARProfile.astro
@@ -132,50 +132,60 @@ const { glaceonSrc, twitterSrc, githubSrc, qiitaSrc } = Astro.props;
 
   function closeAR() {
     stopAllCameraStreams();
+    document.documentElement.classList.remove('ar-mode');
+    document.body.classList.remove('ar-mode');
     const url = new URL(window.location.href);
     url.searchParams.delete('mode');
     window.location.href = url.toString();
   }
 
-  function applyARViewportStyles() {
-    const fullscreenStyle = {
-      position: 'fixed',
-      inset: '0',
-      width: '100vw',
-      height: '100vh',
-      objectFit: 'cover',
-    };
+  // AR.js は内部で video / canvas / body に position・width・height などの
+  // インラインスタイルを強制上書きする (copyElementSizeTo / onResizeElement)。
+  // 縦画面の場合 canvas 幅が `4 * height / 3` の固定計算になり横幅が圧縮される。
+  // そのため !important 付きの CSS でビューポート全体を覆うように強制する。
+  function injectARStyles() {
+    if (document.getElementById('ar-profile-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'ar-profile-styles';
+    style.textContent = `
+      @keyframes ar-spin { to { transform: rotate(360deg); } }
 
-    document.querySelectorAll('video').forEach((video) => {
-      Object.assign(video.style, fullscreenStyle, {
-        zIndex: '1',
-        pointerEvents: 'none',
-      });
-    });
+      html.ar-mode, body.ar-mode {
+        margin: 0 !important;
+        padding: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        overflow: hidden !important;
+        background: #000 !important;
+      }
 
-    document.querySelectorAll('canvas').forEach((canvas) => {
-      Object.assign(canvas.style, fullscreenStyle, {
-        zIndex: '2',
-      });
-    });
-  }
+      body.ar-mode video,
+      body.ar-mode canvas.a-canvas,
+      body.ar-mode .a-canvas,
+      body.ar-mode #arjs-video {
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        right: 0 !important;
+        bottom: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        margin: 0 !important;
+        object-fit: cover !important;
+        object-position: center !important;
+      }
 
-  function getARViewportConfig() {
-    const displayWidth = Math.max(window.innerWidth, 1);
-    const displayHeight = Math.max(window.innerHeight, 1);
-    const isPortrait = displayHeight >= displayWidth;
-    const baseWidth = isPortrait ? 480 : 640;
-    const baseHeight = Math.round((baseWidth * displayHeight) / displayWidth);
-
-    return {
-      displayWidth,
-      displayHeight,
-      canvasWidth: baseWidth,
-      canvasHeight: baseHeight,
-    };
+      body.ar-mode video { z-index: 1 !important; pointer-events: none; }
+      body.ar-mode canvas.a-canvas,
+      body.ar-mode .a-canvas { z-index: 2 !important; }
+    `;
+    document.head.appendChild(style);
   }
 
   function buildARShell() {
+    injectARStyles();
+    document.documentElement.classList.add('ar-mode');
+    document.body.classList.add('ar-mode');
     document.body.innerHTML = `
       <div id="ar-ui-bar" style="position:fixed;top:0;left:0;right:0;z-index:9999;display:flex;justify-content:space-between;align-items:center;padding:12px 16px;background:rgba(0,0,0,0.6);">
         <span style="color:#FEF3C7;font-size:15px;font-weight:bold;letter-spacing:0.05em;">AR プロフィール</span>
@@ -190,9 +200,7 @@ const { glaceonSrc, twitterSrc, githubSrc, qiitaSrc } = Astro.props;
         <div style="width:48px;height:48px;border:4px solid rgba(255,255,255,0.3);border-top-color:white;border-radius:50%;animation:ar-spin 1s linear infinite;"></div>
         <p style="font-size:14px;opacity:0.8;margin:0;">AR を初期化中...</p>
       </div>
-      <style>@keyframes ar-spin{to{transform:rotate(360deg)}}</style>
     `;
-    document.body.style.cssText = 'overflow:hidden;margin:0;padding:0;background:#000;';
     document.getElementById('ar-close-btn').addEventListener('click', closeAR);
   }
 
@@ -212,21 +220,18 @@ const { glaceonSrc, twitterSrc, githubSrc, qiitaSrc } = Astro.props;
       document.getElementById('ar-marker-hint').style.display = 'block';
 
       // ---- Scene ----
-      const { displayWidth, displayHeight, canvasWidth, canvasHeight } = getARViewportConfig();
+      // canvasWidth / canvasHeight / displayWidth / displayHeight は指定しない。
+      // AR.js のデフォルト (640x480) に委ね、映像は CSS の object-fit: cover で
+      // 画面全体に伸ばさず中央クロップ表示する。
       const scene = document.createElement('a-scene');
       scene.setAttribute('arjs', [
         'sourceType: webcam',
         'debugUIEnabled: false',
         'detectionMode: mono',
         'maxDetectionRate: 60',
-        `displayWidth: ${displayWidth}`,
-        `displayHeight: ${displayHeight}`,
-        `canvasWidth: ${canvasWidth}`,
-        `canvasHeight: ${canvasHeight}`,
       ].join('; '));
       scene.setAttribute('vr-mode-ui', 'enabled: false');
       scene.setAttribute('renderer', 'logarithmicDepthBuffer: true; precision: medium;');
-      scene.style.cssText = 'position:fixed;inset:0;width:100vw;height:100vh;';
 
       // ---- Assets ----
       const assets = document.createElement('a-assets');
@@ -308,12 +313,9 @@ const { glaceonSrc, twitterSrc, githubSrc, qiitaSrc } = Astro.props;
       scene.appendChild(camera);
 
       document.body.appendChild(scene);
-      applyARViewportStyles();
 
-      // loaded 後に z-index 調整とマーカー監視を設定
+      // loaded 後にマーカー監視を設定
       scene.addEventListener('loaded', () => {
-        applyARViewportStyles();
-
         const markerEl = document.getElementById('ar-marker');
         const hint = document.getElementById('ar-marker-hint');
         if (markerEl && hint) {
@@ -321,9 +323,6 @@ const { glaceonSrc, twitterSrc, githubSrc, qiitaSrc } = Astro.props;
           markerEl.addEventListener('markerLost',  () => { hint.style.display = 'block'; });
         }
       });
-
-      window.addEventListener('resize', applyARViewportStyles);
-      window.addEventListener('orientationchange', applyARViewportStyles);
 
     } catch (err) {
       const loading = document.getElementById('ar-loading');


### PR DESCRIPTION
## 概要

`develop` ブランチで実装中の AR プロフィール機能について、以下 2 件の不具合を修正します。

- ARプロフィールが表示されない
- 表示された場合、横幅が圧縮されて表示されてしまう

## 原因

AR.js (3.4.5 / `aframe-ar.js`) は `ArToolkitSource` 内部の `onResizeElement` / `copyElementSizeTo` で **video・canvas・body** 要素に対して `width` / `height` / `margin` / `position` をインラインスタイルで強制的に書き換えます。特に **縦画面 (window.innerHeight > innerWidth) の場合**、canvas 幅を固定で `4 * height / 3` に計算してしまうため、縦長ビューポートに対してランドスケープ 4:3 比のキャンバスが押し込まれ、見た目上「横幅が圧縮された」状態になっていました。

```js
// AR.js 3.4.5 aframe-ar.js 抜粋 (縦画面側の分岐)
A.style.height     = this.domElement.style.height;
A.style.width      = 4 * parseInt(A.style.height) / 3 + "px";
A.style.marginLeft = (window.innerWidth - parseInt(A.style.width)) / 2 + "px";
```

さらに、`copyElementSizeTo(document.body)` も呼ばれるため `body` 自体にも `width` / `margin` が付与され、既存の Tailwind クラス (`w-screen` 等) と競合してレイアウトが崩れていました。

従来の実装では `applyARViewportStyles()` で JS からインラインスタイルを書き戻していましたが、**AR.js の `onResize` ハンドラが後続のフレームで再上書きする**ため、リサイズ直後や初期化直後に圧縮表示が再発していました。また、渡していた `canvasWidth` / `canvasHeight` / `displayWidth` / `displayHeight` がビデオソース比率 (既定 640x480) と合わず、内部レンダリングバッファとカメラ映像のアスペクト比不一致でプレーンが描画されないケースもありました。

## 修正内容

- `body.ar-mode` スコープで **`!important` 付きの CSS** を `<style>` 要素として `<head>` に注入。
  - `video`, `canvas.a-canvas`, `#arjs-video` を `position: fixed; width: 100vw; height: 100vh; object-fit: cover;` に固定し、AR.js のインラインスタイルを常に上回るように。
  - `html.ar-mode`, `body.ar-mode` にも `width: 100vw; height: 100vh; margin: 0;` を強制し、AR.js が body にサイズを書き込んでも崩れない。
- JS で一度きり style を当てていた `applyARViewportStyles` / `getARViewportConfig` を削除。
- `<a-scene arjs="...">` から `displayWidth` / `displayHeight` / `canvasWidth` / `canvasHeight` を除去し、AR.js のデフォルト (ビデオソース 640x480) に委譲。レンダリングバッファとソースのアスペクト比を一致させることで、プロフィールカード / SNS アイコンが確実に表示されるようにする。
- AR モード終了時 (`closeAR`) に `html` / `body` から `ar-mode` クラスを外して、元のページ CSS を復元。

## Test plan

- [ ] モバイル実機 (縦画面) で「???」ボタン → AR 起動 → マーカーかざしで **プロフィールカード + SNS アイコン 3 個** が横幅圧縮なしで表示される
- [ ] マーカーを外すと下部ヒントが表示され、再度マーカーを検出すると消える
- [ ] 右上 ✕ ボタンで AR を終了し、自己紹介ページに戻れる / 戻った後も通常ページの横幅が崩れていない
- [ ] PC では従来どおり PC 用モーダル (「スマホで開いて…」) が表示される
- [ ] 横画面 (横持ち) でもプロフィールカードが歪まず表示される

https://claude.ai/code/session_01Ph3n6QhPqBi2U4PSFgWLQt